### PR TITLE
Handle dict-based names in contact payloads

### DIFF
--- a/app/routers/webhook.py
+++ b/app/routers/webhook.py
@@ -99,8 +99,18 @@ def _extract_contacts_from_contacts_field(contacts_raw: str) -> list[dict]:
         obj = json.loads(contacts_raw)
         items = obj if isinstance(obj, list) else [obj]
         for it in items:
-            name = (it.get("name") or it.get("display_name") or
-                    (it.get("first_name","") + " " + it.get("last_name","")).strip() or None)
+            name_field = it.get("name")
+            name = None
+            if isinstance(name_field, dict):
+                name = ((name_field.get("formatted_name") or "").strip()
+                        or (f"{(name_field.get('first_name') or '').strip()} "
+                            f"{(name_field.get('last_name') or '').strip()}").strip()
+                        or None)
+            else:
+                name = (name_field or "").strip() or None
+            if not name:
+                name = (it.get("display_name") or
+                        (it.get("first_name", "") + " " + it.get("last_name", "")).strip() or None)
             wa_id = it.get("wa_id")
             if wa_id:
                 out.append({"wa": f"whatsapp:+{_digits_only(str(wa_id))}", "name": name})


### PR DESCRIPTION
## Summary
- update contact extraction to read formatted_name and first/last names when the name field is a dict
- retain support for legacy string name payloads while populating contact names

## Testing
- python - <<'PY'
import os
os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest')
os.environ.setdefault('TWILIO_AUTH_TOKEN', 'token')
from unittest import mock
with mock.patch('twilio.rest.Client'):
    from app.routers.webhook import _extract_contacts_from_contacts_field
payload = [{
    "name": {
        "formatted_name": "John Doe",
        "first_name": "John",
        "last_name": "Doe",
    },
    "phones": [{"phone": "+972501234567"}]
}]
print(_extract_contacts_from_contacts_field(__import__('json').dumps(payload)))
PY
- python - <<'PY'
import os
os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest')
os.environ.setdefault('TWILIO_AUTH_TOKEN', 'token')
from unittest import mock
with mock.patch('twilio.rest.Client'):
    from app.routers.webhook import _extract_contacts_from_contacts_field
payload = [{
    "name": {
        "first_name": "John",
        "last_name": "Doe",
    },
    "phones": [{"phone": "+972501234567"}]
}]
print(_extract_contacts_from_contacts_field(__import__('json').dumps(payload)))
PY

------
https://chatgpt.com/codex/tasks/task_e_68cb46595b8483238b17049b7a7d2961