### PR TITLE
Add vCard contact ingestion for WhatsApp webhook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv==1.0.1
 pytz==2024.1
 pydantic==2.9.2
 python-multipart==0.0.9
+requests==2.32.3


### PR DESCRIPTION
## Summary
- add requests dependency for downloading Twilio media payloads
- extend the WhatsApp webhook with vCard parsing and fetching helpers
- hook vCard-derived contacts into the universal capture flow for vault + referral + INIT handling

## Testing
- `python -m compileall app` *(fails: existing indentation error in app/flows/ranges.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4227447c8323a2b5658aa18c09d5