### PR TITLE
Fix INIT message using incorrect event name

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -319,17 +319,20 @@ async def run_event(event_id: str):
     id_idx = header_map.get("event_id")
     phone_idx = header_map.get("supplier_phone")
     name_idx = header_map.get("supplier_name")
+    event_name_idx = header_map.get("event_name")
 
-    if id_idx is None or phone_idx is None or name_idx is None:
+    if id_idx is None or phone_idx is None or name_idx is None or event_name_idx is None:
         raise HTTPException(status_code=500, detail="Missing columns in Events sheet")
 
     rows = ws.get_all_values()
     supplier_phone = ""
     supplier_name = ""
+    event_name = ""
     for row in rows[1:]:
         if id_idx < len(row) and (row[id_idx] or "").strip() == event_id:
             supplier_phone = row[phone_idx] if phone_idx < len(row) else ""
             supplier_name = row[name_idx] if name_idx < len(row) else ""
+            event_name = row[event_name_idx] if event_name_idx < len(row) else ""
             break
 
     if not supplier_phone:
@@ -344,7 +347,8 @@ async def run_event(event_id: str):
         raise HTTPException(status_code=500, detail="Missing CONTENT_SID_INIT_QR env var")
 
     variables = {
-        "1": supplier_name or "",
+        "1": event_name or "",
+        "2": supplier_name or "",
         "5": _clean_event_id(event_id),
     }
 


### PR DESCRIPTION
## Summary
- read the event name column when preparing INIT messages
- send both the event name and supplier name to the content template so the correct event appears

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd58e261648323a49ebc5c169e83dd