### PR TITLE
Add event edit and delete management to UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ Endpoints:
 UI (MVP)
 - /ui → Add a new event
 - /ui/events → Manage events & send INIT manually
+
+## UI (MVP) — Manage Events
+- `/ui` — Add a new event
+- `/ui/events` — View & manage all events
+  - **Send INIT** — Manually trigger INIT to the contact of that event
+  - **Edit** — Update event name/date/time/contact/phone in the Events sheet
+  - **Delete** — Cascade delete this event from:
+    - Events
+    - ContactsReferrals
+    - ContactsVault: remove the event_id from `event_ids_json` arrays
+  - Deletion does not recall messages already sent.

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -49,6 +49,30 @@ def _normalize_phone(num: str) -> str:
     return f"whatsapp:{e164}"
 
 
+def _normalize_phone_e164(num: str) -> str:
+    """Best-effort normalization to E.164 without channel prefixes."""
+
+    value = (num or "").strip()
+    if not value:
+        return ""
+    if value.startswith("+"):
+        digits = re.sub(r"\D", "", value[1:])
+        return f"+{digits}" if digits else ""
+    if value.startswith("00"):
+        digits = re.sub(r"\D", "", value[2:])
+        return f"+{digits}" if digits else ""
+    digits = re.sub(r"\D", "", value)
+    if not digits:
+        return ""
+    if digits.startswith("972"):
+        return f"+{digits}"
+    if digits.startswith("0"):
+        return f"+972{digits[1:]}"
+    if digits.startswith("5"):
+        return f"+972{digits}"
+    return f"+{digits}"
+
+
 def _render_page(title: str, body: str) -> str:
     return f"""
     <!doctype html>
@@ -194,55 +218,67 @@ async def add_event(
 
 @router.get("/ui/events", response_class=HTMLResponse)
 async def list_events() -> HTMLResponse:
-    ss = sheets.open_sheet()
-    events_name = os.getenv("SHEET_EVENTS_NAME")
-    if not events_name:
-        raise HTTPException(status_code=500, detail="SHEET_EVENTS_NAME env var is not set")
-    ws = sheets.get_worksheet(ss, events_name)
-    headers = sheets.get_headers(ws)
-    rows = ws.get_all_values()
-
-    header_map = {_header_key(h): idx for idx, h in enumerate(headers)}
-
-    required_keys = [
-        "event_id",
-        "event_name",
-        "event_date",
-        "event_time",
-        "supplier_name",
-        "supplier_phone",
-        "status",
-    ]
-    missing = [k for k in required_keys if k not in header_map]
-    if missing:
+    try:
+        events = sheets.list_events()
+    except Exception as exc:
+        logger.exception("Failed to list events: %s", exc)
         body = (
             "<div class=\"alert alert-danger\" role=\"alert\">"
-            f"Missing columns in Events sheet: {', '.join(missing)}"
+            "Failed to load Events sheet. Check server logs."
             "</div>"
         )
         html = _render_page("Events", body)
         return HTMLResponse(content=html, status_code=500)
 
-    table_rows: List[str] = []
-    for row in rows[1:]:
-        if not any(cell.strip() for cell in row):
-            continue
-        event_id = row[header_map.get("event_id", 0)] if header_map.get("event_id") is not None and header_map["event_id"] < len(row) else ""
-        name = row[header_map.get("event_name", 0)] if header_map.get("event_name") is not None and header_map["event_name"] < len(row) else ""
-        date = row[header_map.get("event_date", 0)] if header_map.get("event_date") is not None and header_map["event_date"] < len(row) else ""
-        time = row[header_map.get("event_time", 0)] if header_map.get("event_time") is not None and header_map["event_time"] < len(row) else ""
-        supplier = row[header_map.get("supplier_name", 0)] if header_map.get("supplier_name") is not None and header_map["supplier_name"] < len(row) else ""
-        phone = row[header_map.get("supplier_phone", 0)] if header_map.get("supplier_phone") is not None and header_map["supplier_phone"] < len(row) else ""
-        status = row[header_map.get("status", 0)] if header_map.get("status") is not None and header_map["status"] < len(row) else ""
+    status_variants = {
+        "pending": "secondary",
+        "confirmed": "success",
+        "awaiting_supplier": "warning",
+        "awaiting": "warning",
+        "cancelled": "danger",
+        "done": "success",
+    }
 
-        event_id_display = escape(event_id)
-        run_url = f"/ui/run_event/{quote(event_id)}"
-        button = ""
+    table_rows: List[str] = []
+    for row in events:
+        event_id = (row.get("event_id") or "").strip()
+        name = row.get("event_name") or ""
+        date = row.get("event_date") or ""
+        time = row.get("event_time") or ""
+        supplier = row.get("supplier_name") or ""
+        phone = row.get("supplier_phone") or ""
+        status = (row.get("status") or "").strip()
+
+        status_badge = "<span class=\"text-muted\">—</span>"
+        if status:
+            variant = status_variants.get(status.lower(), "info")
+            status_badge = f"<span class=\"badge text-bg-{variant}\">{escape(status)}</span>"
+
+        actions = []
         if event_id:
-            button = (
-                f"<form method=\"post\" action=\"{run_url}\" class=\"d-inline\">"
-                f"<button class=\"btn btn-sm btn-outline-primary\" type=\"submit\">Send INIT</button>"
-                "</form>"
+            run_url = f"/ui/run_event/{quote(event_id)}"
+            edit_url = f"/ui/edit/{quote(event_id)}"
+            delete_url = f"/ui/delete/{quote(event_id)}"
+
+            actions.append(
+                """
+                <form method=\"post\" action=\"{run_url}\" class=\"d-inline\">
+                  <button class=\"btn btn-sm btn-success\" type=\"submit\">Send INIT</button>
+                </form>
+                """.format(run_url=escape(run_url))
+            )
+            actions.append(
+                """
+                <a href=\"{edit_url}\" class=\"btn btn-sm btn-outline-primary\">Edit</a>
+                """.format(edit_url=escape(edit_url))
+            )
+            actions.append(
+                """
+                <form method=\"post\" action=\"{delete_url}\" class=\"d-inline\" onsubmit=\"return confirm('Delete this event and all related data?');\">
+                  <input type=\"hidden\" name=\"confirm\" value=\"1\">
+                  <button class=\"btn btn-sm btn-outline-danger\" type=\"submit\">Delete</button>
+                </form>
+                """.format(delete_url=escape(delete_url))
             )
 
         table_rows.append(
@@ -255,17 +291,17 @@ async def list_events() -> HTMLResponse:
               <td>{supplier}</td>
               <td>{phone}</td>
               <td>{status}</td>
-              <td>{button}</td>
+              <td class=\"text-end\"><div class=\"d-flex flex-wrap gap-2 justify-content-end\">{actions}</div></td>
             </tr>
             """.format(
-                event_id=event_id_display,
+                event_id=escape(event_id),
                 name=escape(name),
                 date=escape(date),
                 time=escape(time),
                 supplier=escape(supplier),
                 phone=escape(phone),
-                status=escape(status),
-                button=button,
+                status=status_badge,
+                actions="".join(actions),
             )
         )
 
@@ -290,7 +326,7 @@ async def list_events() -> HTMLResponse:
                 <th scope=\"col\">Supplier</th>
                 <th scope=\"col\">Phone</th>
                 <th scope=\"col\">Status</th>
-                <th scope=\"col\"></th>
+                <th scope=\"col\" class=\"text-end\">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -308,32 +344,13 @@ async def list_events() -> HTMLResponse:
 
 @router.post("/ui/run_event/{event_id}")
 async def run_event(event_id: str):
-    ss = sheets.open_sheet()
-    events_name = os.getenv("SHEET_EVENTS_NAME")
-    if not events_name:
-        raise HTTPException(status_code=500, detail="SHEET_EVENTS_NAME env var is not set")
-    ws = sheets.get_worksheet(ss, events_name)
-    headers = sheets.get_headers(ws)
-    header_map = {_header_key(h): idx for idx, h in enumerate(headers)}
+    row = sheets.get_event_by_id(event_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Event not found")
 
-    id_idx = header_map.get("event_id")
-    phone_idx = header_map.get("supplier_phone")
-    name_idx = header_map.get("supplier_name")
-    event_name_idx = header_map.get("event_name")
-
-    if id_idx is None or phone_idx is None or name_idx is None or event_name_idx is None:
-        raise HTTPException(status_code=500, detail="Missing columns in Events sheet")
-
-    rows = ws.get_all_values()
-    supplier_phone = ""
-    supplier_name = ""
-    event_name = ""
-    for row in rows[1:]:
-        if id_idx < len(row) and (row[id_idx] or "").strip() == event_id:
-            supplier_phone = row[phone_idx] if phone_idx < len(row) else ""
-            supplier_name = row[name_idx] if name_idx < len(row) else ""
-            event_name = row[event_name_idx] if event_name_idx < len(row) else ""
-            break
+    supplier_phone = row.get("supplier_phone") or ""
+    supplier_name = row.get("supplier_name") or ""
+    event_name = row.get("event_name") or ""
 
     if not supplier_phone:
         raise HTTPException(status_code=404, detail="Event not found or missing phone")
@@ -357,5 +374,115 @@ async def run_event(event_id: str):
     except Exception as exc:
         logger.exception("Failed to send INIT content for %s: %s", event_id, exc)
         raise HTTPException(status_code=500, detail="Failed to send INIT message") from exc
+
+    return RedirectResponse(url="/ui/events", status_code=303)
+
+
+@router.get("/ui/edit/{event_id}", response_class=HTMLResponse)
+async def edit_event(event_id: str) -> HTMLResponse:
+    row = sheets.get_event_by_id(event_id)
+    if not row:
+        return HTMLResponse(content="Event not found", status_code=404)
+
+    event_name = row.get("event_name") or ""
+    event_date = row.get("event_date") or ""
+    event_time = row.get("event_time") or ""
+    supplier_name = row.get("supplier_name") or ""
+    supplier_phone = row.get("supplier_phone") or ""
+
+    form = """
+    <div class=\"row justify-content-center\">
+      <div class=\"col-lg-6\">
+        <div class=\"card shadow-sm\">
+          <div class=\"card-header bg-primary text-white\">
+            Edit Event <span class=\"badge bg-light text-dark ms-2\">{event_id}</span>
+          </div>
+          <div class=\"card-body\">
+            <form method=\"post\" action=\"/ui/edit/{event_id_url}\">
+              <div class=\"mb-3\">
+                <label class=\"form-label\" for=\"event_name\">Event name</label>
+                <input class=\"form-control\" id=\"event_name\" name=\"event_name\" type=\"text\" value=\"{event_name}\" required>
+              </div>
+              <div class=\"row\">
+                <div class=\"col-md-6 mb-3\">
+                  <label class=\"form-label\" for=\"event_date\">Event date</label>
+                  <input class=\"form-control\" id=\"event_date\" name=\"event_date\" type=\"date\" value=\"{event_date}\" required>
+                </div>
+                <div class=\"col-md-6 mb-3\">
+                  <label class=\"form-label\" for=\"event_time\">Event time</label>
+                  <input class=\"form-control\" id=\"event_time\" name=\"event_time\" type=\"time\" value=\"{event_time}\" required>
+                </div>
+              </div>
+              <div class=\"mb-3\">
+                <label class=\"form-label\" for=\"supplier_name\">Supplier name</label>
+                <input class=\"form-control\" id=\"supplier_name\" name=\"supplier_name\" type=\"text\" value=\"{supplier_name}\" required>
+              </div>
+              <div class=\"mb-3\">
+                <label class=\"form-label\" for=\"supplier_phone\">Supplier phone</label>
+                <input class=\"form-control\" id=\"supplier_phone\" name=\"supplier_phone\" type=\"text\" value=\"{supplier_phone}\" required>
+              </div>
+              <div class=\"d-flex justify-content-between\">
+                <a class=\"btn btn-outline-secondary\" href=\"/ui/events\">Cancel</a>
+                <button class=\"btn btn-primary\" type=\"submit\">Save changes</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+    """.format(
+        event_id=escape(event_id),
+        event_id_url=quote(event_id),
+        event_name=escape(event_name),
+        event_date=escape(event_date),
+        event_time=escape(event_time),
+        supplier_name=escape(supplier_name),
+        supplier_phone=escape(supplier_phone),
+    )
+
+    html = _render_page(f"Edit {event_id}", form)
+    return HTMLResponse(content=html)
+
+
+@router.post("/ui/edit/{event_id}")
+async def update_event(
+    event_id: str,
+    event_name: str = Form(...),
+    event_date: str = Form(...),
+    event_time: str = Form(...),
+    supplier_name: str = Form(...),
+    supplier_phone: str = Form(...),
+): 
+    normalized_phone = _normalize_phone_e164(supplier_phone)
+    if not normalized_phone and supplier_phone.strip():
+        normalized_phone = supplier_phone.strip()
+
+    ok = sheets.update_event(
+        event_id,
+        event_name=event_name.strip(),
+        event_date=event_date.strip(),
+        event_time=event_time.strip(),
+        supplier_name=supplier_name.strip(),
+        supplier_phone=normalized_phone,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    return RedirectResponse(url="/ui/events", status_code=303)
+
+
+@router.post("/ui/delete/{event_id}")
+async def delete_event(event_id: str, confirm: str = Form(...)):
+    if confirm != "1":
+        return RedirectResponse(url="/ui/events", status_code=303)
+
+    stats = sheets.cascade_delete_event(event_id)
+    logger.info(
+        "Deleted event %s: %s events, %s referrals, %s vault rows",
+        event_id,
+        stats.get("deleted_events"),
+        stats.get("deleted_referrals"),
+        stats.get("updated_vault_rows"),
+    )
 
     return RedirectResponse(url="/ui/events", status_code=303)

--- a/app/utils/sheets.py
+++ b/app/utils/sheets.py
@@ -1,7 +1,9 @@
-import os, json, base64, logging, re
-import os, json, base64, logging
-
-from typing import Dict, Any, List, Optional
+import base64
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
 import gspread
 from google.oauth2.service_account import Credentials
 
@@ -9,6 +11,9 @@ SCOPE = [
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/drive",
 ]
+
+
+logger = logging.getLogger(__name__)
 
 def _load_creds():
     b64 = os.getenv("GOOGLE_CREDENTIALS_B64")
@@ -55,6 +60,236 @@ def find_col_index(headers: List[str], wanted: List[str]) -> Optional[int]:
 
 def _header_key(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", name.strip().lower())
+
+
+def _require_sheet_name(env_key: str) -> str:
+    value = os.getenv(env_key)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {env_key}")
+    return value
+
+
+def _ensure_row_length(row: List[str], length: int) -> List[str]:
+    """Pad a row list with empty strings up to the desired length."""
+    if len(row) >= length:
+        return row
+    return row + ["" for _ in range(length - len(row))]
+
+
+def list_events() -> List[Dict[str, str]]:
+    """Return Events rows as dicts keyed by headers with string values and blanks for missing cells."""
+
+    spreadsheet = open_sheet()
+    sheet_name = _require_sheet_name("SHEET_EVENTS_NAME")
+    worksheet = get_worksheet(spreadsheet, sheet_name)
+    headers = get_headers(worksheet)
+    normalized_headers = [_header_key(h) for h in headers]
+    rows = worksheet.get_all_values()
+
+    results: List[Dict[str, str]] = []
+    for raw in rows[1:]:
+        if not any((cell or "").strip() for cell in raw):
+            continue
+        padded = _ensure_row_length(list(raw), len(headers))
+        row_dict: Dict[str, str] = {}
+        for idx, header in enumerate(headers):
+            value = padded[idx]
+            if value is None:
+                value = ""
+            else:
+                value = str(value)
+            header_key = header or f"col_{idx}"
+            row_dict[header_key] = value
+            normalized = normalized_headers[idx] if idx < len(normalized_headers) else _header_key(header_key)
+            if normalized:
+                row_dict[normalized] = value
+        results.append(row_dict)
+    return results
+
+
+def get_event_by_id(event_id: str) -> Optional[Dict[str, str]]:
+    """Return a single event-row dict by event_id, or None if not found."""
+
+    normalized_event_id = (event_id or "").strip()
+    if not normalized_event_id:
+        return None
+
+    events = list_events()
+    for row in events:
+        if (row.get("event_id") or row.get("Event ID") or "").strip() == normalized_event_id:
+            return row
+    return None
+
+
+def update_event(
+    event_id: str,
+    *,
+    event_name: str,
+    event_date: str,
+    event_time: str,
+    supplier_name: str,
+    supplier_phone: str,
+) -> bool:
+    """Update row in Events sheet where event_id matches."""
+
+    normalized_event_id = (event_id or "").strip()
+    if not normalized_event_id:
+        return False
+
+    spreadsheet = open_sheet()
+    sheet_name = _require_sheet_name("SHEET_EVENTS_NAME")
+    worksheet = get_worksheet(spreadsheet, sheet_name)
+    headers = get_headers(worksheet)
+    header_map = {_header_key(h): idx for idx, h in enumerate(headers)}
+    id_idx = header_map.get("event_id")
+    if id_idx is None:
+        logger.error("[SHEETS] Missing event_id column when updating event")
+        return False
+
+    rows = worksheet.get_all_values()
+    total_columns = len(headers)
+    for offset, raw in enumerate(rows[1:], start=2):
+        padded = _ensure_row_length(list(raw), total_columns)
+        if (padded[id_idx] or "").strip() != normalized_event_id:
+            continue
+
+        updates: Dict[int, str] = {}
+        for key, value in (
+            ("event_name", event_name),
+            ("event_date", event_date),
+            ("event_time", event_time),
+            ("supplier_name", supplier_name),
+            ("supplier_phone", supplier_phone),
+        ):
+            idx = header_map.get(key)
+            if idx is not None:
+                updates[idx] = value.strip()
+
+        if not updates:
+            return True
+
+        for idx in sorted(updates.keys()):
+            worksheet.update_cell(offset, idx + 1, updates[idx])
+        return True
+
+    return False
+
+
+def delete_events_by_id(event_id: str) -> int:
+    """Delete all rows in Events sheet where event_id equals."""
+
+    normalized_event_id = (event_id or "").strip()
+    if not normalized_event_id:
+        return 0
+
+    spreadsheet = open_sheet()
+    sheet_name = _require_sheet_name("SHEET_EVENTS_NAME")
+    worksheet = get_worksheet(spreadsheet, sheet_name)
+    headers = get_headers(worksheet)
+    header_map = {_header_key(h): idx for idx, h in enumerate(headers)}
+    id_idx = header_map.get("event_id")
+    if id_idx is None:
+        logger.error("[SHEETS] Missing event_id column when deleting events")
+        return 0
+
+    rows = worksheet.get_all_values()
+    delete_rows: List[int] = []
+    for offset, raw in enumerate(rows[1:], start=2):
+        if id_idx < len(raw) and (raw[id_idx] or "").strip() == normalized_event_id:
+            delete_rows.append(offset)
+
+    deleted = 0
+    for row_number in sorted(delete_rows, reverse=True):
+        worksheet.delete_rows(row_number)
+        deleted += 1
+
+    return deleted
+
+
+def delete_referrals_by_event(event_id: str) -> int:
+    """Delete all rows in ContactsReferrals sheet where event_id equals."""
+
+    normalized_event_id = (event_id or "").strip()
+    if not normalized_event_id:
+        return 0
+
+    spreadsheet = open_sheet()
+    sheet_name = _require_sheet_name("SHEET_CONTACTS_REFERRALS_NAME")
+    worksheet = get_worksheet(spreadsheet, sheet_name)
+    headers = get_headers(worksheet)
+    header_map = {_header_key(h): idx for idx, h in enumerate(headers)}
+    event_idx = header_map.get("event_id")
+    if event_idx is None:
+        logger.warning("[SHEETS] Missing event_id column in ContactsReferrals when deleting")
+        return 0
+
+    rows = worksheet.get_all_values()
+    delete_rows: List[int] = []
+    for offset, raw in enumerate(rows[1:], start=2):
+        if event_idx < len(raw) and (raw[event_idx] or "").strip() == normalized_event_id:
+            delete_rows.append(offset)
+
+    deleted = 0
+    for row_number in sorted(delete_rows, reverse=True):
+        worksheet.delete_rows(row_number)
+        deleted += 1
+
+    return deleted
+
+
+def remove_event_from_vault(event_id: str) -> int:
+    """Remove event_id from event_ids_json arrays in ContactsVault sheet."""
+
+    normalized_event_id = (event_id or "").strip()
+    if not normalized_event_id:
+        return 0
+
+    spreadsheet = open_sheet()
+    sheet_name = _require_sheet_name("SHEET_CONTACTS_VAULT_NAME")
+    worksheet = get_worksheet(spreadsheet, sheet_name)
+    headers = get_headers(worksheet)
+    header_map = {_header_key(h): idx for idx, h in enumerate(headers)}
+    json_idx = header_map.get("event_ids_json")
+    if json_idx is None:
+        logger.warning("[SHEETS] Missing event_ids_json column in ContactsVault when removing event")
+        return 0
+
+    rows = worksheet.get_all_values()
+    updated = 0
+    for offset, raw in enumerate(rows[1:], start=2):
+        if json_idx >= len(raw):
+            continue
+        raw_json = raw[json_idx] or ""
+        if not raw_json.strip():
+            continue
+        try:
+            data = json.loads(raw_json)
+        except json.JSONDecodeError:
+            logger.warning("[SHEETS] Invalid JSON in event_ids_json for row %s", offset)
+            continue
+        if not isinstance(data, list):
+            continue
+        filtered = [item for item in data if item != normalized_event_id]
+        if len(filtered) == len(data):
+            continue
+        new_json = json.dumps(filtered, separators=(",", ":"))
+        worksheet.update_cell(offset, json_idx + 1, new_json)
+        updated += 1
+
+    return updated
+
+
+def cascade_delete_event(event_id: str) -> Dict[str, int]:
+    """Cascade delete event data across all sheets and return stats."""
+
+    deleted_events = delete_events_by_id(event_id)
+    deleted_referrals = delete_referrals_by_event(event_id)
+    updated_vault_rows = remove_event_from_vault(event_id)
+    return {
+        "deleted_events": deleted_events,
+        "deleted_referrals": deleted_referrals,
+        "updated_vault_rows": updated_vault_rows,
+    }
 
 
 def append_message_log(spreadsheet, row: Dict[str, Any]):


### PR DESCRIPTION
## Summary
- add sheet utility helpers to list, update, and cascade delete event data
- extend the FastAPI UI with edit/delete flows and improved event table actions
- document the management actions available in the UI

## Testing
- python -m compileall app *(fails: existing indentation error in app/flows/ranges.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5e3637fc8323b1280861967adc26